### PR TITLE
Add Railtie to auto-load subscribers at boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ breaking changes as the API settles through real-world consumer integration.
 
 ## [Unreleased]
 
+### Added
+
+- `Acta::Railtie` — auto-loads projection / handler / reactor classes at boot
+  so they self-register before the first emit, even in Rails dev mode where
+  Zeitwerk would otherwise lazy-load them on first reference. Without this,
+  a projection that nothing has touched yet stays unsubscribed: the emit
+  succeeds, the event row is written, and the projection silently never runs.
+  Configurable via `config.acta.{projection,handler,reactor}_paths`; defaults
+  to `app/projections`, `app/handlers`, `app/reactors`. Set a path list to
+  `[]` to opt out. Closes #7.
+
+### Changed
+
+- `Acta.register_projection` is now idempotent — registering the same
+  projection class twice is a no-op instead of double-dispatching events.
+
 ## [0.1.1]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -129,6 +129,24 @@ Projections run synchronously inside the emit transaction. If they raise,
 the entire emit rolls back — the event row isn't written, reactors don't
 fire, base handlers don't fire.
 
+Projections register themselves with Acta the first time their class is
+loaded (via `Class.inherited`). Acta's Railtie eagerly loads everything
+under `app/projections`, `app/handlers`, and `app/reactors` on each
+`config.to_prepare`, so subscribers are wired up before the first request
+— including in dev mode where Zeitwerk would otherwise wait until
+something explicitly references the constant. If your subscribers live
+elsewhere, point Acta at them:
+
+```ruby
+# config/application.rb
+config.acta.projection_paths = %w[app/projections app/read_models]
+config.acta.handler_paths    = %w[app/handlers]
+config.acta.reactor_paths    = %w[app/reactors]
+```
+
+Set a path list to `[]` to disable auto-loading and manage subscriber
+lifecycle yourself.
+
 Replay at any time:
 
 ```ruby

--- a/lib/acta.rb
+++ b/lib/acta.rb
@@ -16,6 +16,7 @@ require_relative "acta/projection"
 require_relative "acta/reactor"
 require_relative "acta/reactor_job"
 require_relative "acta/command"
+require_relative "acta/railtie" if defined?(::Rails::Railtie)
 
 module Acta
   def self.adapter
@@ -129,7 +130,7 @@ module Acta
   end
 
   def self.register_projection(klass)
-    projection_classes << klass
+    projection_classes << klass unless projection_classes.include?(klass)
   end
 
   def self.rebuild!

--- a/lib/acta/railtie.rb
+++ b/lib/acta/railtie.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails/railtie"
+
+module Acta
+  # Forces projection / handler / reactor classes to load at boot, so they can
+  # register themselves with Acta before the first event is emitted.
+  #
+  # Without this, Zeitwerk lazy-loads them on first reference. A projection that
+  # nothing has touched yet is silently unsubscribed — emits succeed, the event
+  # row is written, but the projection never runs and the read model goes stale.
+  # No error, no warning. See https://github.com/whoojemaflip/acta/issues/7.
+  #
+  # Configurable via `config.acta.{projection,handler,reactor}_paths` if your app
+  # puts subscribers somewhere other than the conventional `app/projections`,
+  # `app/handlers`, `app/reactors`. Set a path list to `[]` to opt out.
+  class Railtie < ::Rails::Railtie
+    DEFAULT_PROJECTION_PATHS = %w[app/projections].freeze
+    DEFAULT_HANDLER_PATHS    = %w[app/handlers].freeze
+    DEFAULT_REACTOR_PATHS    = %w[app/reactors].freeze
+
+    config.acta = ActiveSupport::OrderedOptions.new
+
+    initializer "acta.subscriber_path_defaults" do |app|
+      cfg = app.config.acta
+      cfg.projection_paths = DEFAULT_PROJECTION_PATHS.dup if cfg.projection_paths.nil?
+      cfg.handler_paths    = DEFAULT_HANDLER_PATHS.dup    if cfg.handler_paths.nil?
+      cfg.reactor_paths    = DEFAULT_REACTOR_PATHS.dup    if cfg.reactor_paths.nil?
+    end
+
+    initializer "acta.eager_load_subscribers" do |app|
+      app.config.to_prepare do
+        Acta::Railtie.eager_load_subscribers!(app)
+      end
+    end
+
+    def self.eager_load_subscribers!(app)
+      subscriber_paths(app).each { |path| eager_load_path(path) }
+    end
+
+    def self.subscriber_paths(app)
+      cfg = app.config.acta
+      relative = [ *cfg.projection_paths, *cfg.handler_paths, *cfg.reactor_paths ].compact.uniq
+      relative.map { |path| app.root.join(path).to_s }.select { |path| Dir.exist?(path) }
+    end
+
+    def self.eager_load_path(path)
+      if rails_zeitwerk_loader_for(path)&.respond_to?(:eager_load_dir)
+        rails_zeitwerk_loader_for(path).eager_load_dir(path)
+      else
+        Dir.glob(File.join(path, "**/*.rb")).sort.each { |file| require file }
+      end
+    end
+
+    def self.rails_zeitwerk_loader_for(path)
+      return nil unless defined?(::Rails) && ::Rails.respond_to?(:autoloaders)
+
+      autoloaders = ::Rails.autoloaders
+      [ autoloaders.main, autoloaders.once ].compact.find do |loader|
+        loader.respond_to?(:dirs) && loader.dirs.any? { |dir| path == dir || path.start_with?("#{dir}/") }
+      end
+    end
+    private_class_method :rails_zeitwerk_loader_for
+  end
+end

--- a/spec/acta/railtie_spec.rb
+++ b/spec/acta/railtie_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "fileutils"
+require "pathname"
+require "active_support/ordered_options"
+require "acta/railtie"
+
+RSpec.describe Acta::Railtie do
+  let(:tmp_root) { Pathname.new(Dir.mktmpdir("acta-railtie")) }
+
+  let(:app) do
+    root = tmp_root
+    acta_cfg = ActiveSupport::OrderedOptions.new
+    cfg = Object.new
+    cfg.define_singleton_method(:acta) { acta_cfg }
+    fake = Object.new
+    fake.define_singleton_method(:root)   { root }
+    fake.define_singleton_method(:config) { cfg }
+    fake
+  end
+
+  before do
+    Acta.reset_handlers!
+  end
+
+  after do
+    Acta.reset_handlers!
+    FileUtils.remove_entry(tmp_root) if tmp_root.exist?
+  end
+
+  def write_subscriber_file(relative, body)
+    full = tmp_root.join(relative)
+    FileUtils.mkdir_p(full.dirname)
+    full.write(body)
+    full
+  end
+
+  it "loads projection files under app/projections so they self-register" do
+    write_subscriber_file("app/projections/example_projection.rb", <<~RUBY)
+      class ExampleProjection < Acta::Projection
+      end
+    RUBY
+
+    app.config.acta.projection_paths = [ "app/projections" ]
+    app.config.acta.handler_paths    = []
+    app.config.acta.reactor_paths    = []
+
+    expect {
+      described_class.eager_load_subscribers!(app)
+    }.to change { Acta.projection_classes.map(&:name) }.from([]).to(include("ExampleProjection"))
+  end
+
+  it "loads handler files under app/handlers" do
+    write_subscriber_file("app/handlers/example_handler.rb", <<~RUBY)
+      class ExampleHandlerWasLoaded
+      end
+    RUBY
+
+    app.config.acta.projection_paths = []
+    app.config.acta.handler_paths    = [ "app/handlers" ]
+    app.config.acta.reactor_paths    = []
+
+    described_class.eager_load_subscribers!(app)
+
+    expect(Object.const_defined?(:ExampleHandlerWasLoaded)).to be(true)
+  ensure
+    Object.send(:remove_const, :ExampleHandlerWasLoaded) if defined?(ExampleHandlerWasLoaded)
+  end
+
+  it "skips configured paths that don't exist on disk" do
+    app.config.acta.projection_paths = [ "app/projections" ]
+    app.config.acta.handler_paths    = []
+    app.config.acta.reactor_paths    = []
+
+    expect { described_class.eager_load_subscribers!(app) }.not_to raise_error
+  end
+
+  it "is idempotent — loading twice doesn't double-register a projection" do
+    write_subscriber_file("app/projections/idempotent_projection.rb", <<~RUBY)
+      class IdempotentProjection < Acta::Projection
+      end
+    RUBY
+
+    app.config.acta.projection_paths = [ "app/projections" ]
+    app.config.acta.handler_paths    = []
+    app.config.acta.reactor_paths    = []
+
+    described_class.eager_load_subscribers!(app)
+    described_class.eager_load_subscribers!(app)
+
+    expect(Acta.projection_classes.count { |k| k.name == "IdempotentProjection" }).to eq(1)
+  end
+
+  it "treats nil path lists as the configured defaults so apps don't have to set them" do
+    write_subscriber_file("app/projections/default_path_projection.rb", <<~RUBY)
+      class DefaultPathProjection < Acta::Projection
+      end
+    RUBY
+
+    app.config.acta.projection_paths = described_class::DEFAULT_PROJECTION_PATHS.dup
+    app.config.acta.handler_paths    = described_class::DEFAULT_HANDLER_PATHS.dup
+    app.config.acta.reactor_paths    = described_class::DEFAULT_REACTOR_PATHS.dup
+
+    described_class.eager_load_subscribers!(app)
+
+    expect(Acta.projection_classes.map(&:name)).to include("DefaultPathProjection")
+  end
+
+  describe "subscriber_paths" do
+    it "returns absolute paths only for directories that exist" do
+      FileUtils.mkdir_p(tmp_root.join("app/projections"))
+
+      app.config.acta.projection_paths = [ "app/projections" ]
+      app.config.acta.handler_paths    = [ "app/handlers" ] # not created
+      app.config.acta.reactor_paths    = []
+
+      expect(described_class.subscriber_paths(app)).to eq([ tmp_root.join("app/projections").to_s ])
+    end
+
+    it "deduplicates overlapping path lists" do
+      FileUtils.mkdir_p(tmp_root.join("app/subscribers"))
+
+      app.config.acta.projection_paths = [ "app/subscribers" ]
+      app.config.acta.handler_paths    = [ "app/subscribers" ]
+      app.config.acta.reactor_paths    = [ "app/subscribers" ]
+
+      expect(described_class.subscriber_paths(app)).to eq([ tmp_root.join("app/subscribers").to_s ])
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds `Acta::Railtie` to eagerly load projection, handler, and reactor classes at Rails boot time, ensuring they self-register before the first event is emitted. This fixes a critical issue where projections could silently fail to subscribe in development mode due to Zeitwerk's lazy-loading behavior.

## Key Changes

- **New `Acta::Railtie` class** that:
  - Eagerly loads subscriber files from configurable paths (`app/projections`, `app/handlers`, `app/reactors`)
  - Runs on each `config.to_prepare` to handle reloads in development
  - Integrates with Rails' Zeitwerk autoloader when available, falls back to manual `require`
  - Deduplicates overlapping path lists and skips non-existent directories

- **Configuration support** via `config.acta.{projection,handler,reactor}_paths`:
  - Defaults to conventional paths if not explicitly set
  - Can be set to `[]` to opt out of auto-loading
  - Allows custom subscriber locations

- **Made `Acta.register_projection` idempotent**:
  - Prevents double-registration when the same projection class is loaded multiple times
  - Uses `include?` check before adding to the registry

- **Updated documentation** in README and CHANGELOG explaining the problem, solution, and configuration options

## Implementation Details

- The Railtie uses `Class.inherited` hooks (already in place) to auto-register subscribers when their classes load
- Handles both Zeitwerk-managed and manually-required files
- Comprehensive test coverage including idempotency, path deduplication, and graceful handling of missing directories
- Fixes issue #7 where projections could silently remain unsubscribed

https://claude.ai/code/session_01DsgHwe6pLZie7VfLt32e1o