### PR TITLE
Fix Postgres adapter spec leaking connection state

### DIFF
--- a/spec/support/postgres_adapter.rb
+++ b/spec/support/postgres_adapter.rb
@@ -23,6 +23,9 @@ module PostgresAdapterSupport
       adapter: "sqlite3",
       database: ":memory:"
     )
+    Acta::Schema.install(ActiveRecord::Base.connection)
+    Acta::Record.reset_column_information
+    Acta.reset_adapter!
   end
 
   def self.with_connection(&block)


### PR DESCRIPTION
## Summary

- `PostgresAdapterSupport.available?` was discarding the SQLite connection set up in `rails_helper.rb` and replacing it with a fresh `:memory:` SQLite — without re-installing the events table. When Postgres wasn't reachable, every spec that ran after the Postgres adapter spec then failed with `no such table: events` in random seed orderings.
- Mirrors what `with_connection` already does in its ensure block: `Acta::Schema.install`, `Acta::Record.reset_column_information`, `Acta.reset_adapter!`.

## Test plan

- [x] `rspec --seed 49907` (the seed that previously surfaced ~30 failures) — 209 examples, 0 failures, 7 pending
- [x] Three additional random seeds — all green
- [x] Postgres adapter spec still pending-skips cleanly when no Postgres server is configured

Closes #10.

https://claude.ai/code/session_01DsgHwe6pLZie7VfLt32e1o

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsgHwe6pLZie7VfLt32e1o)_