### PR TITLE
Add Acta::Testing.default_actor! and with_actor helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ breaking changes as the API settles through real-world consumer integration.
 
 ### Added
 
+- `Acta::Testing.default_actor!(config, **attrs)` — RSpec configuration
+  helper that sets `Acta::Current.actor` before every example and resets
+  it after, eliminating the per-spec boilerplate and the easy-to-forget
+  `Acta::MissingActor` errors that come with it. Defaults to a
+  `system / rspec / test` actor; override any attribute. Closes #8.
+- `Acta::Testing::DSL#with_actor(**attrs) { … }` — block-scoped actor
+  override for individual examples that need to attribute emissions to
+  a specific user. Restores the previous actor when the block returns
+  (or raises).
+
 - `Acta::Railtie` — auto-loads projection / handler / reactor classes at boot
   so they self-register before the first emit, even in Rails dev mode where
   Zeitwerk would otherwise lazy-load them on first reference. Without this,

--- a/README.md
+++ b/README.md
@@ -303,11 +303,45 @@ require "acta/testing"
 require "acta/testing/matchers"
 
 RSpec.configure do |config|
+  Acta::Testing.default_actor!(config)
+  config.include Acta::Testing::DSL
+
   config.around(:each, :active_record) do |example|
     Acta::Testing.test_mode { example.run }
   end
 end
 ```
+
+### Default actor
+
+`Acta.emit` requires `Acta::Current.actor` to be set — every event needs
+a known author. `Acta::Testing.default_actor!(config)` adds a
+`before(:each)` that sets a default `system / rspec / test` actor and an
+`after(:each)` that resets it, so specs (and the commands they call)
+don't trip `Acta::MissingActor`. Override any attribute to match your
+project's vocabulary:
+
+```ruby
+Acta::Testing.default_actor!(config, type: "user", id: "test-user-1", source: "spec")
+```
+
+For an individual example that needs to attribute emissions to a
+specific actor, scope an override with `with_actor`:
+
+```ruby
+include Acta::Testing::DSL
+
+it "records the user as the actor" do
+  with_actor(type: "user", id: user.id, source: "web") do
+    PlaceOrder.call(...)
+  end
+
+  expect(Acta::Record.last.actor_id).to eq(user.id)
+end
+```
+
+`with_actor` restores the surrounding actor when the block returns or
+raises.
 
 ### RSpec matchers
 

--- a/lib/acta/testing.rb
+++ b/lib/acta/testing.rb
@@ -4,6 +4,8 @@ require "active_job"
 
 module Acta
   module Testing
+    DEFAULT_ACTOR_ATTRIBUTES = { type: "system", id: "rspec", source: "test" }.freeze
+
     module_function
 
     # Runs the given block with ActiveJob's :inline adapter, so async
@@ -15,6 +17,34 @@ module Acta
       yield
     ensure
       ActiveJob::Base.queue_adapter = original
+    end
+
+    # Configures RSpec to set Acta::Current.actor before every example, so
+    # specs that emit (directly or via a command) don't trip Acta::MissingActor.
+    # Resets Acta::Current after each example so state doesn't leak.
+    #
+    #   # spec/rails_helper.rb
+    #   require "acta/testing"
+    #   RSpec.configure do |config|
+    #     Acta::Testing.default_actor!(config)
+    #   end
+    #
+    # Override the default actor's attributes per project:
+    #
+    #   Acta::Testing.default_actor!(config, type: "user", id: "test-user-1", source: "spec")
+    #
+    # Individual specs can still override Acta::Current.actor inline (or
+    # use Acta::Testing::DSL#with_actor for a scoped override).
+    def default_actor!(config, **attributes)
+      attrs = DEFAULT_ACTOR_ATTRIBUTES.merge(attributes)
+
+      config.before(:each) do
+        Acta::Current.actor = Acta::Actor.new(**attrs)
+      end
+
+      config.after(:each) do
+        Acta::Current.reset
+      end
     end
   end
 end

--- a/lib/acta/testing/dsl.rb
+++ b/lib/acta/testing/dsl.rb
@@ -57,6 +57,18 @@ module Acta
         )
       end
 
+      # Run the block with a different Acta::Current.actor, restoring the
+      # previous actor afterward (even if the block raises). Useful for
+      # asserting an emit attributes the right user when the surrounding
+      # spec's default actor would otherwise overwrite it.
+      def with_actor(**attributes)
+        previous = Acta::Current.actor
+        Acta::Current.actor = Acta::Actor.new(**attributes)
+        yield
+      ensure
+        Acta::Current.actor = previous
+      end
+
       # Assert that running Acta.rebuild! twice produces the same projected
       # state. The block returns a snapshot of the relevant state (whatever
       # the app considers authoritative for this projection).

--- a/spec/acta/testing_default_actor_spec.rb
+++ b/spec/acta/testing_default_actor_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "acta/testing"
+
+RSpec.describe Acta::Testing, ".default_actor!" do
+  let(:rspec_config) { RSpec::Core::Configuration.new }
+
+  let(:example_group) do
+    RSpec.describe("acta default_actor host") do
+      include Acta::Testing
+    end
+  end
+
+  def run_example(example_group, &body)
+    example_group.example("default actor host", &body)
+    runner = RSpec::Core::Reporter.new(rspec_config)
+    example_group.run(runner)
+  end
+
+  before do
+    Acta::Current.reset
+  end
+
+  after do
+    Acta::Current.reset
+  end
+
+  it "sets Acta::Current.actor before each example with a default system actor" do
+    described_class.default_actor!(example_group)
+
+    captured = nil
+    run_example(example_group) { captured = Acta::Current.actor }
+
+    expect(captured).to be_a(Acta::Actor)
+    expect(captured.type).to eq("system")
+    expect(captured.id).to eq("rspec")
+    expect(captured.source).to eq("test")
+  end
+
+  it "accepts overrides for the actor's attributes" do
+    described_class.default_actor!(example_group, type: "user", id: "test-user-1", source: "spec")
+
+    captured = nil
+    run_example(example_group) { captured = Acta::Current.actor }
+
+    expect(captured.type).to eq("user")
+    expect(captured.id).to eq("test-user-1")
+    expect(captured.source).to eq("spec")
+  end
+
+  it "merges overrides on top of the defaults" do
+    described_class.default_actor!(example_group, id: "custom-id")
+
+    captured = nil
+    run_example(example_group) { captured = Acta::Current.actor }
+
+    expect(captured.type).to eq("system")
+    expect(captured.id).to eq("custom-id")
+    expect(captured.source).to eq("test")
+  end
+
+  it "resets Acta::Current after each example" do
+    described_class.default_actor!(example_group)
+
+    run_example(example_group) { } # set actor in before; reset in after
+
+    expect(Acta::Current.actor).to be_nil
+  end
+
+  it "lets an individual example override the actor inline" do
+    described_class.default_actor!(example_group)
+
+    captured = nil
+    run_example(example_group) do
+      Acta::Current.actor = Acta::Actor.new(type: "user", id: "u_1", source: "web")
+      captured = Acta::Current.actor
+    end
+
+    expect(captured.type).to eq("user")
+    expect(captured.id).to eq("u_1")
+  end
+end

--- a/spec/acta/testing_dsl_spec.rb
+++ b/spec/acta/testing_dsl_spec.rb
@@ -108,4 +108,41 @@ RSpec.describe Acta::Testing::DSL, :active_record do
     then_emitted renamed_class
     then_emitted_nothing_else
   end
+
+  describe "#with_actor" do
+    it "sets Acta::Current.actor for the duration of the block" do
+      previous = Acta::Current.actor
+
+      captured = nil
+      with_actor(type: "user", id: "u_42", source: "web") do
+        captured = Acta::Current.actor
+      end
+
+      expect(captured.type).to eq("user")
+      expect(captured.id).to eq("u_42")
+      expect(captured.source).to eq("web")
+      expect(Acta::Current.actor).to eq(previous)
+    end
+
+    it "restores the previous actor even when the block raises" do
+      previous = Acta::Current.actor
+
+      expect {
+        with_actor(type: "user", id: "u_1") { raise "boom" }
+      }.to raise_error(RuntimeError, "boom")
+
+      expect(Acta::Current.actor).to eq(previous)
+    end
+
+    it "attributes emitted events to the scoped actor" do
+      with_actor(type: "user", id: "u_42", source: "web") do
+        Acta.emit(added_class.new(book_id: "w_1", name: "Foo"))
+      end
+
+      record = Acta::Record.last
+      expect(record.actor_type).to eq("user")
+      expect(record.actor_id).to eq("u_42")
+      expect(record.source).to eq("web")
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- `Acta::Testing.default_actor!(config, **attrs)` — RSpec configuration helper that sets `Acta::Current.actor` before every example and resets it after. Defaults to a `system / rspec / test` actor; override `type:`, `id:`, `source:`.
- `Acta::Testing::DSL#with_actor(**attrs) { … }` — block-scoped actor override for examples that need to attribute emissions to a specific user. Restores the previous actor when the block returns or raises.
- README "Testing" section now shows the canonical spec_helper wiring (`Acta::Testing.default_actor!(config)` + `config.include Acta::Testing::DSL`) and a worked `with_actor` example.

The motivation: `Acta.emit` requires `Acta::Current.actor` to be set, which is the right production behaviour but creates per-spec boilerplate and easy-to-forget `Acta::MissingActor` errors. Every consumer was rolling their own slightly-different `before(:each)`. This blesses the canonical one.

## Test plan

- [x] `rspec spec/acta/testing_default_actor_spec.rb` — 5 examples, 0 failures (defaults, overrides, merging, after-reset, inline override)
- [x] `rspec spec/acta/testing_dsl_spec.rb` — 8 examples, 0 failures (3 new `#with_actor` cases plus existing DSL cases)
- [x] Full suite (excluding `postgres_adapter_spec.rb`, which requires a Postgres server — see #10 / PR #11): 210 examples, 0 failures

Closes #8.

https://claude.ai/code/session_01DsgHwe6pLZie7VfLt32e1o

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsgHwe6pLZie7VfLt32e1o)_