### PR TITLE
Make Acta::Command#emits variadic for multi-event commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ breaking changes as the API settles through real-world consumer integration.
 
 ## [Unreleased]
 
+### Changed
+
+- `Acta::Command.emits` is now variadic — `emits EventA, EventB, ...`
+  for commands that conditionally emit different events. Stream config
+  is still inherited from the first event class; explicit `stream`
+  declarations still take precedence. The runtime does not enforce that
+  only the listed events are emitted (it never did) — `emits` is a
+  hint, not a contract. Backwards-compatible: single-arg `emits A`
+  works exactly as before. New `Command.emitted_event_classes` returns
+  the full list; `Command.emitted_event_class` (singular) still
+  returns the first. Closes #5.
+
 ### Added
 
 - `Acta::Testing.default_actor!(config, **attrs)` — RSpec configuration

--- a/README.md
+++ b/README.md
@@ -187,6 +187,26 @@ explicit `stream :order, key: :order_id` form instead if the command
 operates on a different aggregate than its primary event, or if it
 doesn't emit an Acta event.
 
+For commands that conditionally emit different events for the same
+aggregate, list them all so the declaration stops being a half-truth:
+
+```ruby
+class RegisterTrail < Acta::Command
+  emits TrailRegistered, TrailUpdated   # variadic — any of these may be emitted
+
+  def call
+    existing = Trail.find_by(id:)
+    existing ? emit(TrailUpdated.new(...)) : emit(TrailRegistered.new(...))
+  end
+end
+```
+
+Stream config is inherited from the first event class; the rest are
+documentation. The runtime does not enforce that only the listed events
+get emitted — `emits` is a hint, not a contract. List events that share
+the same aggregate; if the command spans aggregates, declare `stream`
+explicitly instead.
+
 `on_concurrent_write :raise` captures the stream's current sequence at
 command instantiation and asserts the stream hasn't moved by emit time.
 If another writer has appended to the stream in between, the command

--- a/lib/acta/command.rb
+++ b/lib/acta/command.rb
@@ -20,8 +20,8 @@ module Acta
         @stream_key_attribute = key
       end
 
-      # Declare the primary event class this command emits. The command
-      # inherits stream_type and stream_key_attribute from that event,
+      # Declare the event class(es) this command might emit. The command
+      # inherits stream_type and stream_key_attribute from the FIRST event,
       # removing the duplicate declaration in the common case:
       #
       #   class OrderRenamed < Acta::Event
@@ -34,23 +34,56 @@ module Acta
       #     on_concurrent_write :raise
       #     # ...
       #   end
-      def emits(event_class)
-        unless event_class.respond_to?(:stream_type) && event_class.respond_to?(:stream_key_attribute)
-          raise ArgumentError,
-                "emits expects a class with stream_type and stream_key_attribute (typically an Acta::Event subclass)"
+      #
+      # Commands that conditionally emit different events for the same
+      # aggregate can list them all — handy for documentation and so the
+      # `emits` line stops being a half-truth:
+      #
+      #   class RegisterTrail < Acta::Command
+      #     emits TrailRegistered, TrailUpdated
+      #
+      #     def call
+      #       existing = Trail.find_by(id:)
+      #       existing ? emit(TrailUpdated.new(...)) : emit(TrailRegistered.new(...))
+      #     end
+      #   end
+      #
+      # The runtime does not enforce that only the listed events are
+      # emitted — `emits` is a hint, not a contract. List the events that
+      # share the same aggregate (and therefore the same stream config),
+      # or use the explicit `stream :type, key: :attr` form when the
+      # command emits across multiple aggregates.
+      def emits(*event_classes)
+        if event_classes.empty?
+          raise ArgumentError, "emits requires at least one event class"
         end
 
-        @emitted_event_class = event_class
+        event_classes.each do |event_class|
+          unless event_class.respond_to?(:stream_type) && event_class.respond_to?(:stream_key_attribute)
+            raise ArgumentError,
+                  "emits expects classes with stream_type and stream_key_attribute (typically Acta::Event subclasses), got #{event_class.inspect}"
+          end
+        end
+
+        @emitted_event_classes = event_classes
       end
 
-      attr_reader :emitted_event_class, :concurrent_write_action
+      def emitted_event_classes
+        @emitted_event_classes || []
+      end
+
+      def emitted_event_class
+        emitted_event_classes.first
+      end
+
+      attr_reader :concurrent_write_action
 
       def stream_type
-        @stream_type || @emitted_event_class&.stream_type
+        @stream_type || emitted_event_class&.stream_type
       end
 
       def stream_key_attribute
-        @stream_key_attribute || @emitted_event_class&.stream_key_attribute
+        @stream_key_attribute || emitted_event_class&.stream_key_attribute
       end
 
       # Declare how the command handles concurrent writes to its stream.

--- a/spec/acta/command_emits_spec.rb
+++ b/spec/acta/command_emits_spec.rb
@@ -128,5 +128,97 @@ RSpec.describe "Acta::Command with `emits`", :active_record do
         Class.new(Acta::Command) { emits String }
       }.to raise_error(ArgumentError, /stream_type and stream_key_attribute/)
     end
+
+    it "raises ArgumentError when emits is called with no arguments" do
+      expect {
+        Class.new(Acta::Command) { emits }
+      }.to raise_error(ArgumentError, /requires at least one event class/)
+    end
+
+    it "raises ArgumentError when any of multiple emits arguments lacks stream hooks" do
+      expect {
+        Class.new(Acta::Command) { emits BookRenamed, String }
+      }.to raise_error(ArgumentError, /stream_type and stream_key_attribute.*String/)
+    end
+  end
+
+  describe "with multiple event classes (variadic)" do
+    let(:other_event_class) do
+      klass = Class.new(Acta::Event) do
+        stream :book, key: :book_id
+        attribute :book_id, :string
+        attribute :reason, :string
+        validates :book_id, :reason, presence: true
+      end
+      stub_const("BookArchived", klass)
+      klass
+    end
+
+    let(:command_class) do
+      other_event_class
+
+      klass = Class.new(Acta::Command) do
+        emits BookRenamed, BookArchived
+
+        param :book_id, :string
+        param :new_name, :string
+        param :archive, :boolean, default: false
+        param :reason, :string
+
+        def call
+          if archive
+            emit BookArchived.new(book_id:, reason:)
+          else
+            emit BookRenamed.new(book_id:, new_name:)
+          end
+        end
+      end
+      stub_const("UpdateBook", klass)
+      klass
+    end
+
+    it "exposes all listed events via emitted_event_classes" do
+      expect(command_class.emitted_event_classes).to eq([ BookRenamed, BookArchived ])
+    end
+
+    it "still inherits stream_type from the first event class" do
+      expect(command_class.stream_type).to eq("book")
+    end
+
+    it "still inherits stream_key_attribute from the first event class" do
+      expect(command_class.stream_key_attribute).to eq(:book_id)
+    end
+
+    it "emitted_event_class returns the first event class for backward compat" do
+      expect(command_class.emitted_event_class).to eq(BookRenamed)
+    end
+
+    it "lets the command emit any of the listed events at runtime" do
+      command_class.call(book_id: "w_1", new_name: "Foo")
+      command_class.call(book_id: "w_1", archive: true, reason: "out of print")
+
+      events = Acta.events.all
+      expect(events.map(&:class)).to eq([ BookRenamed, BookArchived ])
+    end
+
+    it "does not enforce that only listed events are emitted (emits is a hint, not a contract)" do
+      Class.new(Acta::Event) do
+        attribute :book_id, :string
+        validates :book_id, presence: true
+      end.tap { |c| stub_const("BookSurprise", c) }
+
+      surprise_command = Class.new(Acta::Command) do
+        emits BookRenamed
+        param :book_id, :string
+
+        def call
+          emit BookSurprise.new(book_id:)
+        end
+      end
+      stub_const("SurpriseCommand", surprise_command)
+
+      expect { surprise_command.call(book_id: "w_1") }.not_to raise_error
+      expect(Acta.events.last).to be_a(BookSurprise)
+    end
   end
 end


### PR DESCRIPTION
## Summary

- `Acta::Command.emits` is now variadic — `emits EventA, EventB, ...` lets commands list every event class they might emit, so the declaration stops being a half-truth for commands that emit different events conditionally.
- Stream config is still inherited from the first event class. Explicit `stream :type, key: :attr` still wins. Single-arg `emits A` still works byte-for-byte the same — backwards-compatible.
- New `Command.emitted_event_classes` (plural) returns the full list. `Command.emitted_event_class` (singular) still returns the first.
- Calling `emits` with zero arguments now raises `ArgumentError` instead of silently doing nothing.

## Why

Per #5: the `emits` macro conflated two jobs — declaring stream config (which it actually inherits via constant lookup) and declaring the emitted event type (which the runtime never enforces). The second job was purely documentary, and for cascade / branching commands it was a documented lie:

```ruby
class RegisterTrail < Acta::Command
  emits TrailRegistered          # ← claims one thing
  def call
    existing ? emit(TrailUpdated.new(...))    # ← actually does another
            : emit(TrailRegistered.new(...))
  end
end
```

Letting the declaration list the full set restores honesty without changing the runtime.

## Test plan

- [x] `spec/acta/command_emits_spec.rb` — 15 examples, 0 failures (7 pre-existing + 8 new for variadic semantics, validation, and runtime independence)
- [x] Full suite: 225 examples, 0 failures, 7 pending (the Postgres-only specs)
- [x] All previously-existing single-arg `emits` callsites continue to work without change

Closes #5.

https://claude.ai/code/session_01DsgHwe6pLZie7VfLt32e1o

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsgHwe6pLZie7VfLt32e1o)_