### PR TITLE
Acta::Command.call returns the primary emitted event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ breaking changes as the API settles through real-world consumer integration.
 
 ## [Unreleased]
 
+### Changed
+
+- `Acta::Command.call` now returns the primary emitted event when the
+  command has an `emits` declaration. The "primary" event is the first
+  emitted event whose class matches `emits`. Commands that emit nothing
+  (idempotent no-ops) return `nil`. Removes the `existing&.id ||
+  SecureRandom.uuid_v7` boilerplate that callers were threading through
+  to recover the new aggregate's id. Commands without an `emits`
+  declaration retain the legacy passthrough behavior — `Command.call`
+  returns whatever the user's `#call` returned. Closes #4.
+
+  New `Command#emitted_events` returns every event emitted during the
+  current invocation (in order) for callers that need the full cascade
+  rather than just the primary.
+
 ### Added
 
 - `Acta::Testing.default_actor!(config, **attrs)` — RSpec configuration

--- a/README.md
+++ b/README.md
@@ -177,8 +177,20 @@ class PlaceOrder < Acta::Command
   end
 end
 
-PlaceOrder.call(customer_id: "c_1", total_cents: 4200)
+event = PlaceOrder.call(customer_id: "c_1", total_cents: 4200)
+event.order_id   # => "order_…" — the id the command generated
 ```
+
+When a command has an `emits` declaration, `Command.call` returns the
+emitted event (matched by class). Callers can grab `event.order_id`
+without threading boilerplate like `existing&.id || SecureRandom.uuid_v7`
+through their controllers and importers. Idempotent no-op runs return
+`nil`. Cascade commands that emit additional events (see #5) return the
+primary event matching `emits`; the rest are accessible on the instance
+via `command_instance.emitted_events`.
+
+Commands without `emits` keep the legacy passthrough behavior —
+`Command.call` returns whatever the user's `#call` returned.
 
 `emits OrderPlaced` derives the command's `stream_type` and
 `stream_key_attribute` from the event class's own declaration — no

--- a/lib/acta/command.rb
+++ b/lib/acta/command.rb
@@ -5,8 +5,24 @@ module Acta
     class << self
       alias_method :param, :attribute
 
+      # Instantiate the command with the given params, run it, and return
+      # the primary emitted event when an `emits` declaration is present —
+      # so callers don't have to dig the new aggregate's id out via a
+      # roundtrip (`existing.id || SecureRandom.uuid_v7` boilerplate at
+      # every call site disappears). Returns `nil` if the command was
+      # idempotent and emitted nothing.
+      #
+      # Commands without an `emits` declaration retain the legacy
+      # behavior — `Command.call` returns whatever the user's `#call`
+      # method returned. Adding `emits` to an existing command is the
+      # opt-in signal to switch to event-returning semantics.
       def call(**params)
-        new(**params).call
+        instance = new(**params)
+        result = instance.call
+
+        return result if emitted_event_class.nil?
+
+        instance.primary_emitted_event
       end
 
       # Declare the aggregate this command operates on. Two forms:
@@ -89,6 +105,21 @@ module Acta
 
     def emit(event)
       Acta.emit(event, expected_sequence: @captured_sequence)
+      emitted_events << event
+      event
+    end
+
+    def emitted_events
+      @emitted_events ||= []
+    end
+
+    # The first emitted event whose class matches the `emits` declaration;
+    # nil if the command was idempotent and emitted nothing matching.
+    def primary_emitted_event
+      primary_class = self.class.emitted_event_class
+      return emitted_events.last if primary_class.nil?
+
+      emitted_events.find { |event| event.is_a?(primary_class) }
     end
 
     private

--- a/spec/acta/command_return_value_spec.rb
+++ b/spec/acta/command_return_value_spec.rb
@@ -1,0 +1,191 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Acta::Command.call return value", :active_record do
+  let(:created_class) do
+    klass = Class.new(Acta::Event) do
+      stream :order, key: :order_id
+      attribute :order_id, :string
+      attribute :customer_id, :string
+      validates :order_id, :customer_id, presence: true
+    end
+    stub_const("OrderCreated", klass)
+    klass
+  end
+
+  let(:cascade_class) do
+    klass = Class.new(Acta::Event) do
+      stream :order, key: :order_id
+      attribute :order_id, :string
+      attribute :line_id, :string
+      validates :order_id, :line_id, presence: true
+    end
+    stub_const("OrderLineAdded", klass)
+    klass
+  end
+
+  before do
+    Acta.reset_adapter!
+    Acta.reset_handlers!
+    Acta::Current.actor = Acta::Actor.new(type: "system")
+    created_class
+    cascade_class
+  end
+
+  after do
+    Acta::Current.reset
+    Acta.reset_adapter!
+    Acta.reset_handlers!
+  end
+
+  describe "with `emits` declared" do
+    let(:command_class) do
+      klass = Class.new(Acta::Command) do
+        emits OrderCreated
+
+        param :customer_id, :string
+
+        def call
+          emit OrderCreated.new(order_id: "o_#{customer_id}", customer_id:)
+        end
+      end
+      stub_const("CreateOrder", klass)
+      klass
+    end
+
+    it "returns the emitted event" do
+      result = command_class.call(customer_id: "c_1")
+
+      expect(result).to be_a(OrderCreated)
+      expect(result.order_id).to eq("o_c_1")
+      expect(result.customer_id).to eq("c_1")
+    end
+
+    it "returns the event regardless of what the user's #call returns" do
+      noisy_command = Class.new(Acta::Command) do
+        emits OrderCreated
+        param :customer_id, :string
+
+        def call
+          emit OrderCreated.new(order_id: "o_1", customer_id:)
+          "trailing-string-ignored"
+        end
+      end
+      stub_const("NoisyCommand", noisy_command)
+
+      expect(noisy_command.call(customer_id: "c_1")).to be_a(OrderCreated)
+    end
+
+    it "returns nil when the command is idempotent and emits nothing" do
+      noop_command = Class.new(Acta::Command) do
+        emits OrderCreated
+        param :customer_id, :string
+
+        def call
+          # idempotent: nothing to do
+        end
+      end
+      stub_const("NoopCommand", noop_command)
+
+      expect(noop_command.call(customer_id: "c_1")).to be_nil
+    end
+
+    it "returns the primary event for cascade commands that emit additional events" do
+      cascade_command = Class.new(Acta::Command) do
+        emits OrderCreated
+
+        param :customer_id, :string
+
+        def call
+          emit OrderCreated.new(order_id: "o_99", customer_id:)
+          emit OrderLineAdded.new(order_id: "o_99", line_id: "l_1")
+          emit OrderLineAdded.new(order_id: "o_99", line_id: "l_2")
+        end
+      end
+      stub_const("CascadeCommand", cascade_command)
+
+      result = cascade_command.call(customer_id: "c_1")
+
+      expect(result).to be_a(OrderCreated)
+      expect(result.order_id).to eq("o_99")
+    end
+
+    it "exposes all emitted events on the instance via #emitted_events" do
+      cascade_command = Class.new(Acta::Command) do
+        emits OrderCreated
+        param :customer_id, :string
+
+        def call
+          emit OrderCreated.new(order_id: "o_1", customer_id:)
+          emit OrderLineAdded.new(order_id: "o_1", line_id: "l_1")
+        end
+      end
+      stub_const("InstanceCommand", cascade_command)
+
+      instance = cascade_command.new(customer_id: "c_1")
+      instance.call
+
+      expect(instance.emitted_events.map(&:class)).to eq([ OrderCreated, OrderLineAdded ])
+    end
+
+    it "Command#emit still returns the emitted event so user code can chain on it" do
+      capture = nil
+
+      capturing_command = Class.new(Acta::Command) do
+        emits OrderCreated
+        param :customer_id, :string
+        param :captor, :string
+
+        define_method(:call) do
+          captured = emit OrderCreated.new(order_id: "o_1", customer_id:)
+          # simulate the user grabbing the event id mid-call
+          capture = captured
+          captured
+        end
+      end
+      stub_const("CapturingCommand", capturing_command)
+
+      capturing_command.call(customer_id: "c_1", captor: "yes")
+
+      expect(capture).to be_a(OrderCreated)
+      expect(capture.order_id).to eq("o_1")
+    end
+  end
+
+  describe "without `emits` declared" do
+    it "returns whatever the user's #call returns (legacy behavior preserved)" do
+      adder = Class.new(Acta::Command) do
+        param :a, :integer
+        param :b, :integer
+        validates :a, :b, presence: true
+
+        def call
+          a + b
+        end
+      end
+      stub_const("Adder", adder)
+
+      expect(adder.call(a: 2, b: 3)).to eq(5)
+    end
+
+    it "returns whatever the user's #call returns even when the command does emit events" do
+      # Without `emits`, Acta has no way to know which event is "primary",
+      # so it doesn't try to guess — it returns the user's return value.
+      stream_command = Class.new(Acta::Command) do
+        stream :order, key: :order_id
+        param :order_id, :string
+        param :customer_id, :string
+
+        def call
+          emit OrderCreated.new(order_id:, customer_id:)
+          :explicit_return
+        end
+      end
+      stub_const("StreamCommand", stream_command)
+
+      result = stream_command.call(order_id: "o_1", customer_id: "c_1")
+      expect(result).to eq(:explicit_return)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- `Acta::Command.call` now returns the first emitted event whose class matches the `emits` declaration. Idempotent no-op runs return `nil`. Callers can do `event = CreateOrder.call(...); event.order_id` instead of threading `existing&.id || SecureRandom.uuid_v7` through call sites.
- New `Command#emitted_events` exposes the full list (in order) for cascade commands that emit additional events beyond the primary.
- Backwards-compatible: commands without `emits` keep the legacy passthrough behavior — `Command.call` returns whatever the user's `#call` returned. The `emits` declaration is the opt-in signal.

## Why

Per #4: callers needing the new aggregate's id had to either generate the id ahead-of-time and pass it as a param (the `existing.id || SecureRandom.uuid_v7` boilerplate the issue cites at every call site), or introspect `Acta::Record.last` after the call. Both leak the command's identity-creation responsibility outward. Returning the event from `Command.call` puts the id where the caller naturally expects to find it.

## Coexistence with #14 (variadic `emits`)

Independent of PR #14. This PR uses `Command.emitted_event_class` (singular) which is preserved by #14 as a backwards-compat shim that returns the first listed event class. Whichever PR merges second will need a trivial conflict resolution at the `class << self` block but the `Command#primary_emitted_event` semantics are unchanged either way (primary = first emitted event matching the `emits` declaration).

## Test plan

- [x] New `spec/acta/command_return_value_spec.rb` — 8 examples covering: returns the event, returns regardless of user's `#call` return, returns nil for no-op, returns the primary for cascade commands, exposes `emitted_events`, `Command#emit` still returns the event, legacy passthrough preserved both with and without `stream` declaration
- [x] Existing `spec/acta/command_spec.rb` — 6 examples still green; the `Adder` and `SayHello` fixtures (no `emits`) keep their legacy return behavior
- [x] Existing `spec/acta/command_emits_spec.rb` — 7 examples still green
- [x] Existing `spec/acta/command_streaming_spec.rb` — 10 examples still green
- [x] Full suite: 225 examples, 0 failures, 7 pending

Closes #4.

https://claude.ai/code/session_01DsgHwe6pLZie7VfLt32e1o

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsgHwe6pLZie7VfLt32e1o)_