### PR TITLE
Add acta_managed! safety net for projection-owned AR models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ breaking changes as the API settles through real-world consumer integration.
 
 ### Added
 
+- `acta_managed!` AR class macro — opt-in safety net for projection-owned
+  models. Once an AR model becomes a projection, writes from anywhere
+  other than the projection bypass the event log and break
+  `Acta.rebuild!` determinism. `acta_managed!` gates every AR write path
+  (save / update / destroy / update_columns / update_all / delete_all /
+  insert_all / upsert_all) on `Acta::Projection.applying?` and raises
+  `Acta::ProjectionWriteError` (or warns, with `on_violation: :warn`)
+  when violated. `Acta::Projection.applying! { … }` is the public escape
+  hatch for fixtures, migrations, and intentional backfills. Closes #6.
+
 - `Acta::Testing.default_actor!(config, **attrs)` — RSpec configuration
   helper that sets `Acta::Current.actor` before every example and resets
   it after, eliminating the per-spec boilerplate and the easy-to-forget

--- a/README.md
+++ b/README.md
@@ -157,6 +157,43 @@ Each projection's `truncate!` runs, then the log is replayed through
 projections. Reactors are skipped during replay (replay is a state
 operation, not a notification one).
 
+#### Guarding projection-owned tables
+
+Once a model is maintained by a projection, *every* other write path
+(controllers, console one-offs, rake tasks, callbacks on other models)
+silently breaks the event log as the source of truth. Opt into a runtime
+guard with `acta_managed!`:
+
+```ruby
+class Order < ApplicationRecord
+  acta_managed!   # writes outside an Acta::Projection raise ProjectionWriteError
+end
+```
+
+Inside an `Acta::Projection` `on EventClass do |e| ... end` block (and
+during `Acta.rebuild!`'s truncate phase), `Acta::Projection.applying?`
+is true and writes pass through. From a controller, console, or
+unrelated callback, they raise:
+
+```ruby
+Order.update_all(status: "cancelled")
+# raise: Acta::ProjectionWriteError — Order is acta_managed!
+#        Emit an event so the projection can update the row, or wrap
+#        intentional out-of-band writes in
+#        `Acta::Projection.applying! { ... }` (fixtures, migrations,
+#        backfills).
+```
+
+For incremental migration, demote violations to warnings:
+
+```ruby
+acta_managed! on_violation: :warn
+```
+
+Test fixtures, data migrations, and one-off backfills can wrap
+intentional out-of-band writes in `Acta::Projection.applying! { ... }`
+to bypass the safety net explicitly.
+
 ### 5. Commands for validated writes
 
 ```ruby

--- a/lib/acta.rb
+++ b/lib/acta.rb
@@ -16,7 +16,13 @@ require_relative "acta/projection"
 require_relative "acta/reactor"
 require_relative "acta/reactor_job"
 require_relative "acta/command"
+require_relative "acta/projection_managed"
 require_relative "acta/railtie" if defined?(::Rails::Railtie)
+
+require "active_support/lazy_load_hooks"
+ActiveSupport.on_load(:active_record) do
+  include Acta::ProjectionManaged
+end
 
 module Acta
   def self.adapter
@@ -81,7 +87,7 @@ module Acta
       event:,
       projection_class: registration[:handler_class]
     ) do
-      registration[:block].call(event)
+      Projection.applying! { registration[:block].call(event) }
     end
   rescue ProjectionError
     raise
@@ -134,7 +140,7 @@ module Acta
   end
 
   def self.rebuild!
-    projection_classes.each(&:truncate!)
+    Projection.applying! { projection_classes.each(&:truncate!) }
     Record.order(:id).find_each do |record|
       event = events.find_by_uuid(record.uuid)
       dispatch(event, kind: :projection)

--- a/lib/acta/errors.rb
+++ b/lib/acta/errors.rb
@@ -71,4 +71,19 @@ module Acta
       super("Replay failed on event id=#{record.id} uuid=#{record.uuid} (#{record.event_type}): #{original.message}")
     end
   end
+
+  class ProjectionWriteError < Error
+    attr_reader :model_class, :write_method
+
+    def initialize(model_class:, write_method:)
+      @model_class = model_class
+      @write_method = write_method
+      super(
+        "Direct #{write_method} on #{model_class.name} bypasses the event log. " \
+        "#{model_class.name} is acta_managed! — its rows are owned by an Acta::Projection. " \
+        "Emit an event so the projection can update the row, or wrap intentional " \
+        "out-of-band writes in `Acta::Projection.applying! { ... }` (fixtures, migrations, backfills)."
+      )
+    end
+  end
 end

--- a/lib/acta/projection.rb
+++ b/lib/acta/projection.rb
@@ -2,6 +2,8 @@
 
 module Acta
   class Projection < Handler
+    APPLYING_FLAG = :acta_projection_applying
+
     def self.inherited(subclass)
       super
       Acta.register_projection(subclass)
@@ -9,6 +11,26 @@ module Acta
 
     def self.truncate!
       # default no-op; apps override to clear their projected state
+    end
+
+    # Mark the current thread as inside projection-side code for the
+    # duration of the block. Acta sets this internally when invoking
+    # projection handlers and during `Acta.rebuild!`'s truncate phase, so
+    # `acta_managed!` AR models know to allow the writes.
+    #
+    # Apps can wrap fixture setup, migrations, or one-off backfill
+    # operations in `Acta::Projection.applying! { ... }` to bypass the
+    # safety net intentionally.
+    def self.applying!
+      previous = Thread.current[APPLYING_FLAG]
+      Thread.current[APPLYING_FLAG] = true
+      yield
+    ensure
+      Thread.current[APPLYING_FLAG] = previous
+    end
+
+    def self.applying?
+      Thread.current[APPLYING_FLAG] == true
     end
   end
 end

--- a/lib/acta/projection_managed.rb
+++ b/lib/acta/projection_managed.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Acta
+  # Marks an ActiveRecord model as projection-managed: its rows are
+  # maintained by an Acta::Projection from the event log, so writes from
+  # anywhere else (controllers, console, rake tasks, callbacks on other
+  # models) bypass the log and break Acta.rebuild!'s determinism.
+  #
+  # Opt in with `acta_managed!` on the AR class:
+  #
+  #   class Trail < ApplicationRecord
+  #     acta_managed!   # raise on out-of-band writes
+  #   end
+  #
+  #   class TrailAlias < ApplicationRecord
+  #     acta_managed! on_violation: :warn   # warn instead, for incremental migration
+  #   end
+  #
+  # Inside an `Acta::Projection` `on EventClass do |e| ... end` block (or
+  # during `Acta.rebuild!`'s truncate phase), `Acta::Projection.applying?`
+  # is true and writes are allowed. Outside, they raise
+  # `Acta::ProjectionWriteError` (or warn if so configured).
+  #
+  # Tests, migrations, and one-off backfills can wrap intentional
+  # out-of-band writes in `Acta::Projection.applying! { ... }` to bypass
+  # the safety net explicitly.
+  module ProjectionManaged
+    extend ActiveSupport::Concern
+
+    GUARDED_CLASS_METHODS = %i[
+      update_all
+      delete_all
+      insert
+      insert!
+      insert_all
+      insert_all!
+      upsert
+      upsert_all
+    ].freeze
+
+    GUARDED_INSTANCE_METHODS = %i[
+      update_columns
+      update_column
+    ].freeze
+
+    VALID_VIOLATION_ACTIONS = %i[ raise warn ].freeze
+
+    class_methods do
+      def acta_managed!(on_violation: :raise)
+        unless VALID_VIOLATION_ACTIONS.include?(on_violation)
+          raise ArgumentError,
+                "acta_managed! on_violation must be one of #{VALID_VIOLATION_ACTIONS.inspect}, got #{on_violation.inspect}"
+        end
+
+        @acta_on_violation = on_violation
+
+        before_save     :_acta_assert_projection_applying!
+        before_destroy  :_acta_assert_projection_applying!
+
+        singleton_class.prepend(ClassWriteGuards)
+      end
+
+      def acta_managed?
+        !@acta_on_violation.nil?
+      end
+
+      def acta_on_violation
+        @acta_on_violation
+      end
+    end
+
+    module ClassWriteGuards
+      ProjectionManaged::GUARDED_CLASS_METHODS.each do |method|
+        define_method(method) do |*args, **kwargs, &block|
+          ProjectionManaged.assert_projection_applying!(self, method)
+          super(*args, **kwargs, &block)
+        end
+      end
+    end
+
+    GUARDED_INSTANCE_METHODS.each do |method|
+      define_method(method) do |*args, **kwargs, &block|
+        ProjectionManaged.assert_projection_applying!(self.class, method)
+        super(*args, **kwargs, &block)
+      end
+    end
+
+    def self.assert_projection_applying!(model_class, write_method)
+      return if Acta::Projection.applying?
+
+      action = model_class.acta_on_violation
+      case action
+      when :raise
+        raise Acta::ProjectionWriteError.new(model_class:, write_method:)
+      when :warn
+        warn "[acta] #{Acta::ProjectionWriteError.new(model_class:, write_method:).message}"
+      end
+    end
+
+    private
+
+    def _acta_assert_projection_applying!
+      ProjectionManaged.assert_projection_applying!(self.class, :save)
+    end
+  end
+end

--- a/spec/acta/projection_managed_spec.rb
+++ b/spec/acta/projection_managed_spec.rb
@@ -1,0 +1,252 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Acta::ProjectionManaged, :active_record do
+  before(:all) do
+    ActiveRecord::Base.connection.create_table(:trails, force: true) do |t|
+      t.string :name
+    end
+    ActiveRecord::Base.connection.create_table(:zones, force: true) do |t|
+      t.string :name
+    end
+  end
+
+  let(:strict_model) do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "trails"
+      acta_managed!
+    end
+    stub_const("Trail", klass)
+    klass
+  end
+
+  let(:warning_model) do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "zones"
+      acta_managed! on_violation: :warn
+    end
+    stub_const("Zone", klass)
+    klass
+  end
+
+  let(:unmanaged_model) do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "trails"
+    end
+    stub_const("UnmanagedTrail", klass)
+    klass
+  end
+
+  before do
+    Acta.reset_handlers!
+    Acta::Current.reset
+    ActiveRecord::Base.connection.execute("DELETE FROM trails")
+    ActiveRecord::Base.connection.execute("DELETE FROM zones")
+  end
+
+  describe "Acta::Projection.applying?" do
+    it "is false outside any projection-side scope" do
+      expect(Acta::Projection.applying?).to be(false)
+    end
+
+    it "is true inside Acta::Projection.applying! { }" do
+      flag = nil
+      Acta::Projection.applying! { flag = Acta::Projection.applying? }
+
+      expect(flag).to be(true)
+    end
+
+    it "restores the previous value after the block (supports nesting)" do
+      Acta::Projection.applying! do
+        expect(Acta::Projection.applying?).to be(true)
+        Acta::Projection.applying! { expect(Acta::Projection.applying?).to be(true) }
+        expect(Acta::Projection.applying?).to be(true)
+      end
+
+      expect(Acta::Projection.applying?).to be(false)
+    end
+
+    it "restores the previous value even when the block raises" do
+      expect {
+        Acta::Projection.applying! { raise "boom" }
+      }.to raise_error(RuntimeError, "boom")
+
+      expect(Acta::Projection.applying?).to be(false)
+    end
+  end
+
+  describe "with on_violation: :raise (default)" do
+    it "raises Acta::ProjectionWriteError on .create! outside a projection" do
+      expect { strict_model.create!(name: "AM/PM") }
+        .to raise_error(Acta::ProjectionWriteError, /Trail.+acta_managed/)
+    end
+
+    it "allows .create! inside Acta::Projection.applying! { }" do
+      Acta::Projection.applying! { strict_model.create!(name: "AM/PM") }
+
+      expect(strict_model.count).to eq(1)
+    end
+
+    it "raises on instance #save" do
+      Acta::Projection.applying! { strict_model.create!(name: "AM/PM") }
+      record = strict_model.first
+      record.name = "Renamed"
+
+      expect { record.save }.to raise_error(Acta::ProjectionWriteError)
+    end
+
+    it "raises on instance #update" do
+      Acta::Projection.applying! { strict_model.create!(name: "AM/PM") }
+
+      expect { strict_model.first.update(name: "Renamed") }
+        .to raise_error(Acta::ProjectionWriteError)
+    end
+
+    it "raises on instance #destroy" do
+      Acta::Projection.applying! { strict_model.create!(name: "AM/PM") }
+
+      expect { strict_model.first.destroy }.to raise_error(Acta::ProjectionWriteError)
+    end
+
+    it "raises on instance #update_columns" do
+      Acta::Projection.applying! { strict_model.create!(name: "AM/PM") }
+
+      expect { strict_model.first.update_columns(name: "Renamed") }
+        .to raise_error(Acta::ProjectionWriteError, /update_columns/)
+    end
+
+    it "raises on class .update_all" do
+      expect { strict_model.update_all(name: "Renamed") }
+        .to raise_error(Acta::ProjectionWriteError, /update_all/)
+    end
+
+    it "raises on class .delete_all" do
+      expect { strict_model.delete_all }
+        .to raise_error(Acta::ProjectionWriteError, /delete_all/)
+    end
+
+    it "raises on class .insert_all" do
+      expect { strict_model.insert_all([ { name: "X" } ]) }
+        .to raise_error(Acta::ProjectionWriteError, /insert_all/)
+    end
+
+    it "raises on class .upsert_all" do
+      expect { strict_model.upsert_all([ { name: "X" } ]) }
+        .to raise_error(Acta::ProjectionWriteError, /upsert_all/)
+    end
+
+    it "allows reads (find, where, count, etc.) without restriction" do
+      Acta::Projection.applying! { strict_model.create!(name: "AM/PM") }
+
+      expect(strict_model.count).to eq(1)
+      expect(strict_model.where(name: "AM/PM").count).to eq(1)
+      expect(strict_model.first.name).to eq("AM/PM")
+    end
+  end
+
+  describe "with on_violation: :warn" do
+    it "writes to $stderr instead of raising on .create!" do
+      expect { warning_model.create!(name: "Cheakamus") }
+        .to output(/\[acta\].+Zone.+acta_managed/).to_stderr
+        .and(change { warning_model.count }.by(1))
+    end
+
+    it "warns on .delete_all but still performs the write" do
+      Acta::Projection.applying! { warning_model.create!(name: "Cheakamus") }
+
+      expect { warning_model.delete_all }
+        .to output(/\[acta\].+delete_all/).to_stderr
+        .and(change { warning_model.count }.from(1).to(0))
+    end
+
+    it "is silent inside Acta::Projection.applying!" do
+      expect {
+        Acta::Projection.applying! { warning_model.create!(name: "Cheakamus") }
+      }.not_to output.to_stderr
+    end
+  end
+
+  describe "without acta_managed! (unmanaged AR models)" do
+    it "imposes zero overhead — writes pass through unchanged" do
+      expect { unmanaged_model.create!(name: "Free") }.not_to raise_error
+      expect { unmanaged_model.update_all(name: "Bulk") }.not_to raise_error
+      expect { unmanaged_model.delete_all }.not_to raise_error
+    end
+
+    it "acta_managed? returns false" do
+      expect(unmanaged_model.acta_managed?).to be(false)
+    end
+  end
+
+  describe "validation" do
+    it "raises ArgumentError on invalid on_violation values" do
+      expect {
+        Class.new(ActiveRecord::Base) do
+          self.table_name = "trails"
+          acta_managed! on_violation: :explode
+        end
+      }.to raise_error(ArgumentError, /on_violation must be one of/)
+    end
+  end
+
+  describe "integration with projection invocation" do
+    let(:event_class) do
+      klass = Class.new(Acta::Event) do
+        attribute :name, :string
+        validates :name, presence: true
+      end
+      stub_const("TrailRegistered", klass)
+      klass
+    end
+
+    let(:projection_class) do
+      managed = strict_model
+      klass = Class.new(Acta::Projection) do
+        define_singleton_method(:truncate!) { managed.delete_all }
+        on TrailRegistered do |event|
+          managed.create!(name: event.name)
+        end
+      end
+      stub_const("TrailProjection", klass)
+      klass
+    end
+
+    before do
+      event_class
+      projection_class
+      Acta::Current.actor = Acta::Actor.new(type: "system")
+    end
+
+    it "lets a projection write to its acta_managed! AR model normally" do
+      expect {
+        Acta.emit(event_class.new(name: "AM/PM"))
+      }.to change { strict_model.count }.from(0).to(1)
+    end
+
+    it "Acta.rebuild! truncates and replays without tripping the safety net" do
+      Acta.emit(event_class.new(name: "AM/PM"))
+      Acta.emit(event_class.new(name: "Microwave Peak"))
+
+      expect { Acta.rebuild! }.not_to raise_error
+      expect(strict_model.count).to eq(2)
+    end
+
+    it "doesn't allow reactors (which run after-commit) to write to managed tables" do
+      reactor = Class.new(Acta::Reactor) do
+        sync!
+        managed = nil
+        define_singleton_method(:set_managed) { |m| managed = m }
+        on TrailRegistered do |_e|
+          managed.create!(name: "from-reactor")
+        end
+      end
+      reactor.set_managed(strict_model)
+      stub_const("TrailReactor", reactor)
+
+      expect {
+        Acta.emit(event_class.new(name: "AM/PM"))
+      }.to raise_error(Acta::ProjectionWriteError)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- New `acta_managed!` AR class macro — opt-in safety net for projection-owned models.
- New `Acta::Projection.applying?` / `Acta::Projection.applying! { … }` thread-local flag. Acta sets it internally during projection handler invocation and during `Acta.rebuild!`'s truncate phase. Apps wrap fixtures / migrations / backfills in `applying! { ... }` to bypass the safety net intentionally.
- New `Acta::ProjectionWriteError` raised when an `acta_managed!` model is written outside a projection. `acta_managed! on_violation: :warn` demotes to a stderr warning for incremental migration.
- Gated write paths: instance `#save / #update / #destroy / #update_columns / #update_column`; class `.update_all / .delete_all / .insert / .insert! / .insert_all / .insert_all! / .upsert / .upsert_all`. Reads are unrestricted.
- Zero overhead on AR models that don't call `acta_managed!` — the concern only adds callbacks and prepends class-method guards when the macro is invoked.

## Why

Per #6: ES's value proposition is "the event log is the source of truth." That's only true if every write path goes through the log. Without enforcement, future contributors (or future-you on a console) will eventually write `RideEffort.update_all(...)` somewhere and the next `Acta.rebuild!` will silently overwrite their change because it never appears in the event log. The whole point of byte-for-byte rebuild determinism is the ability to throw projections away — which only works if no out-of-band writes have crept in.

The `acta_managed!` macro turns "convention enforced by code review" into a runtime guard with a loud, helpful error message pointing at the escape hatch.

## Mechanics

- `Acta::Projection.applying!(&block)` sets a thread-local flag for the duration of the block (nesting-safe, raise-safe).
- `Acta.run_projection` wraps every projection handler invocation with `applying!`.
- `Acta.rebuild!` wraps its `projection_classes.each(&:truncate!)` call with `applying!` so projection-owned `delete_all`s during truncate don't trip the guard.
- The `Acta::ProjectionManaged` concern is included in `ActiveRecord::Base` via `ActiveSupport.on_load(:active_record)`. Calling `acta_managed!` on a model:
  1. Records the `on_violation` action.
  2. Adds `before_save` and `before_destroy` callbacks that assert `Acta::Projection.applying?`.
  3. Prepends `ClassWriteGuards` onto the model's singleton class to gate the bulk write methods.
- Models that never call `acta_managed!` see no callbacks added, no class methods prepended — zero overhead.

## Test plan

- [x] New `spec/acta/projection_managed_spec.rb` — 24 examples covering:
  - `Acta::Projection.applying?` semantics (false by default, nesting, raise-safe restoration)
  - Strict mode raises on every gated path: `.create!`, `#save`, `#update`, `#destroy`, `#update_columns`, `.update_all`, `.delete_all`, `.insert_all`, `.upsert_all`
  - Reads (`.find`, `.where`, `.count`) are unrestricted
  - `applying!` block is the bypass mechanism
  - `:warn` mode writes to stderr instead of raising; still performs the write
  - Models without `acta_managed!` have zero overhead
  - Validation: invalid `on_violation:` raises `ArgumentError`
  - Integration: projections write normally, `Acta.rebuild!` truncates and replays without tripping, reactors are correctly blocked from writing to managed tables (they run after-commit, outside `applying?`)
- [x] Full suite: 241 examples, 0 failures, 7 pending — no regressions in any existing spec

Closes #6.

https://claude.ai/code/session_01DsgHwe6pLZie7VfLt32e1o

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsgHwe6pLZie7VfLt32e1o)_