### PR TITLE
chore: Trusted Publishing release workflow + gemspec mfa hardening

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,83 @@
+name: Release
+
+# Publishes the gem to rubygems.org via Trusted Publishing (OIDC). Triggered
+# by pushing a tag of the form `v*`. The workflow runs the test suite first
+# and only publishes if it's green.
+#
+# Setup (one-time):
+# 1. rubygems.org → Profile → Trusted Publishers → Add a publisher
+# 2. Repository: whoojemaflip/acta
+# 3. Workflow filename: release.yml
+# 4. Environment name: rubygems
+#
+# To cut a release:
+# 1. Bump VERSION in lib/acta/version.rb
+# 2. Move [Unreleased] → [vX.Y.Z] in CHANGELOG.md
+# 3. Commit, tag (`git tag -a vX.Y.Z -m "Release X.Y.Z"`), push tag
+# 4. The action takes over from there
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: Test before release
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_DB: acta_test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    env:
+      ACTA_PG_HOST: localhost
+      ACTA_PG_PORT: 5432
+      ACTA_PG_USER: postgres
+      ACTA_PG_PASSWORD: postgres
+      ACTA_PG_DATABASE: acta_test
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4.1'
+          bundler-cache: true
+      - name: Run the default task
+        run: bundle exec rake
+
+  release:
+    needs: test
+    runs-on: ubuntu-latest
+    name: Publish to rubygems.org
+    environment: rubygems
+
+    permissions:
+      contents: write    # GitHub Release creation
+      id-token: write    # OIDC token for rubygems Trusted Publishing
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4.1'
+          bundler-cache: true
+      - name: Release gem
+        uses: rubygems/release-gem@v1

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 
 # rspec failure tracking
 .rspec_status
+
+# locally-built gem artifacts (released via Trusted Publishing)
+*.gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    acta (0.1.1)
+    acta (0.2.0)
       activejob (>= 8.1)
       activemodel (>= 8.1)
       activerecord (>= 8.1)

--- a/acta.gemspec
+++ b/acta.gemspec
@@ -20,10 +20,10 @@ Gem::Specification.new do |spec|
   spec.license = "MIT"
   spec.required_ruby_version = ">= 3.4"
 
-  spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
   spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/main/CHANGELOG.md"
   spec.metadata["bug_tracker_uri"] = "#{spec.homepage}/issues"
+  spec.metadata["rubygems_mfa_required"] = "true"
 
   gemspec = File.basename(__FILE__)
   spec.files = IO.popen(%w[git ls-files -z], chdir: __dir__, err: IO::NULL) do |ls|


### PR DESCRIPTION
## Summary

Set up automated, keyless gem publishing for the next release.

- `.github/workflows/release.yml` — fires on `v*` tag push, runs the test suite as a gate, then publishes via [Trusted Publishing](https://guides.rubygems.org/trusted-publishing/) (OIDC). No long-lived rubygems API key sits in CI secrets; rubygems mints a one-time token from the GitHub OIDC claim at publish time.
- `acta.gemspec` — set `rubygems_mfa_required = "true"`. Belt-and-braces: even if a manual API key gets used later, pushes must pass MFA. Also drop the duplicate `homepage_uri` metadata key (`spec.homepage` already covers it; setting both triggered a build warning).
- `.gitignore` — ignore locally-built `*.gem` artifacts.

## One-time setup before the next release

The workflow won't authenticate until rubygems.org knows about the publisher. On rubygems.org → Profile → **Trusted Publishers** → **Add a publisher**:

| Field | Value |
|---|---|
| Repository | `whoojemaflip/acta` |
| Workflow filename | `release.yml` |
| Environment name | `rubygems` |

Also create a GitHub Actions environment named `rubygems` on the repo (Settings → Environments → New environment). Optional but standard: gate it on protection rules so only `main` can deploy.

## Releasing once setup is done

```bash
# bump VERSION in lib/acta/version.rb
# move [Unreleased] → [vX.Y.Z] in CHANGELOG.md
git commit -am "Release X.Y.Z"
git tag -a vX.Y.Z -m "Release X.Y.Z"
git push origin main vX.Y.Z
```

The workflow takes it from there.

## Test plan

- [ ] PR review of workflow + gemspec changes
- [ ] After merge: register the publisher on rubygems.org per the table above
- [ ] After register: cut a 0.2.1 (or 0.3.0) bump as a smoke test of the full pipeline; gem appears on https://rubygems.org/gems/acta

🤖 Generated with [Claude Code](https://claude.com/claude-code)