### PR TITLE
release.yml: create GitHub Release after rubygems push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,3 +81,23 @@ jobs:
           bundler-cache: true
       - name: Release gem
         uses: rubygems/release-gem@v1
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          notes=$(awk -v ver="$version" '
+            /^## \[/ {
+              if (in_section) exit
+              if ($0 ~ "^## \\[" ver "\\]") { in_section = 1; next }
+              next
+            }
+            in_section { print }
+          ' CHANGELOG.md)
+          if [ -z "$(echo "$notes" | tr -d "[:space:]")" ]; then
+            echo "::error::No CHANGELOG entry found for version $version"
+            exit 1
+          fi
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --notes "$notes"


### PR DESCRIPTION
## What

Adds a step to the release workflow that creates a GitHub Release for the pushed tag, using the matching CHANGELOG entry as the release notes.

## Why

\`rubygems/release-gem@v1\` runs \`bundle exec rake release\`, which pushes the gem but doesn't create a GitHub Release. v0.2.0 and v0.3.0 both got their GitHub Releases created by hand. Future tags shouldn't need that.

## How

- Strips the \`v\` prefix from \`GITHUB_REF_NAME\` to get the version
- \`awk\` extracts the section between \`## [<version>]\` and the next \`## [\`
- If the section is empty (no CHANGELOG entry for this version), the step fails with a clear error — forces CHANGELOG discipline before tagging
- \`gh release create\` lands the release with the extracted notes

## Test plan

- Workflow runs only on \`v*\` tag push, so no CI exercises it on the PR
- Verified \`awk\` extraction against current CHANGELOG locally for both an existing version (0.3.0) and a non-existent one (9.9.9 returns empty)
- Real validation comes on the next tag push (0.3.1 / 0.4.0)